### PR TITLE
SIGUSR1 now destroys retired workers

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -363,9 +363,9 @@ p.clear_all = function() {
 	this.check_bands = this.check_bands.bind(this); // rebind prototype method to instance
 	this.all_band_furnished_deferred = Q.defer();
 
-	var reason = "full restart";
-
-	var live_workers_copy = this.worker_bands.concat();
+	var
+		reason = "full restart",
+		live_workers_copy = this.worker_bands.concat();
 
 	// Instruct all live workers to retire
 	for (var idx = live_workers_copy.length; idx--; ) {
@@ -375,24 +375,35 @@ p.clear_all = function() {
 		this.retire_worker(worker.pid, reason);
 	}
 
-	// we track the list or retired workers AT THIS POINT. These are the only ones we want to kill.
-	var _self = this;
-	var old_retired_workers = _self.old_workers.concat();
+	this.all_band_furnished_deferred.promise
+		.then(this.clear_all_retired_workers.bind(this, reason))
+		.done();
+};
+
+p.clear_all_retired_workers = function(reason) {
+	var
+		deferred = Q.defer(),
+		_self    = this,
+		reason   = reason || "Retiree cleansing",
+		// we track the list or retired workers AT THIS POINT. These are the only ones we want to kill.
+		old_retired_workers = _self.old_workers.concat();
 
 	// we kill the retired workers with delay, to dampen the migrating hurd effect
 	function destroy_next() {
-		if (old_retired_workers.length <= 0) return;
+		if (old_retired_workers.length <= 0) {
+			return deferred.resolve();
+		}
 		destroyWorker.call(_self, old_retired_workers.shift().pid, reason, 0);
 		setTimeout(destroy_next, _self.options.spawn_delay);
 	}
 
-	this.all_band_furnished_deferred.promise
-		.then(destroy_next)
-		.done();
+	destroy_next();
+
+	return deferred.promise;
 };
 
 p.set_signal_handlers = function() {
-	process.on('SIGUSR1', this.clear_all.bind(this));
+	process.on('SIGUSR1', this.clear_all_retired_workers.bind(this));
 };
 
 p.rate_limited_retire_worker = function(pid, reason_data) {


### PR DESCRIPTION
master.clear_all() is left around even though is it no longer used. clear_all() also uses the newly
introduced clear_all_retired_workers() which returns a promise.

@yangbin @giantballofyarn @lennardseah 