### PR TITLE
Fix: template args {pid: pid} was placed incorrectly T_T

### DIFF
--- a/lib/process_util.js
+++ b/lib/process_util.js
@@ -43,7 +43,7 @@ function ps() {
 }
 
 function getCommand(pid) {
-	return Q.nfcall(fs.readFile, replace('/proc/{pid}/cmdline'), {pid: pid})
+	return Q.nfcall(fs.readFile, replace('/proc/{pid}/cmdline', {pid: pid}))
 		.then(function(res) {
 			return [pid, res.toString().split('\x00')];
 		});


### PR DESCRIPTION
Arg ``{pid: pid}``` was passed to the wrong function :sob: Needs to be repushed if the previous code was deployed.

@lennardseah @giantballofyarn 