### PR TITLE
Bump version to 0.0.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zopim",
   "name": "ipcluster",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "repository": {
     "type": "git",
     "url": "git@github.com:zopim/ipcluster.git"


### PR DESCRIPTION
* Renice retired workers to lower priority than live workers (configurable via init settings, default to 1)
* USR1 signal handler now kills only retired workers

@lennardseah 