### PR TITLE
Stability improvements

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -21,9 +21,9 @@ var default_options = {
 	hostname:            'localhost',
 	num_workers:         os.cpus().length,
 	ports:               [80],
-	connect_timeout:     3 * 1000, // 3s
-	ping_timeout:        5 * 1000, // 5s
-	monitor_interval:    1 * 1000, // 5s
+	connect_timeout:     3  * 1000, // 3s
+	ping_timeout:        10 * 1000, // 10s
+	monitor_interval:    1  * 1000, // 1s
 	totalmaxheap:        512 * 1024 * 1024, // 512 MB
 	spawn_delay:         1511, // large prime number to reduce overlapping cumulation delay
 	soft_kill_timeout:   5 * 1000, // 5s

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -33,7 +33,8 @@ var
 	default_options = {
 		connect_timeout: 5000, // in ms
 		toobusy_lag:     150,  // in ms
-		toobusy_delay:   30    // in s !!!
+
+		health_check_delay: 45 // in s !!!
 	};
 
 function Worker(options, band) {
@@ -241,7 +242,7 @@ p.getInfo = function() {
 		ts_sent: +new Date(),
 		pid:     process.pid,
 		mem:     process.memoryUsage(),
-		toobusy: (process.uptime() <= this.options.toobusy_delay ? false : toobusy()),
+		toobusy: toobusy(),
 		uptime:  process.uptime(),
 		portmap: this.options.portmap,
 		band:    this.band,
@@ -250,6 +251,14 @@ p.getInfo = function() {
 			connection_attempts: this.connection_attempts
 		}
 	};
+
+	// we allow health_check_delay bootup time for the process to settle down
+	// during that period, the process will report that it is healthy
+	// this is to account for startup surge, and allow enough time for the garbage collector to reclaim some of the initialization memory
+	if (process.uptime() <= this.options.health_check_delay) {
+		info.toobusy = false;
+		for (var key in info.mem) info.mem[key] = 1;
+	}
 
 	if (this.ts_retirement)
 		info.ts_retirement = this.ts_retirement;


### PR DESCRIPTION
* Increment default ping_timeout time to 10s
* Report healthy values at startup, during the first ```health_check_delay``` seconds (set to 45)

@lennardseah @giantballofyarn @yangbin @dineshsaravanan 