### PR TITLE
Use a more generous toobusy dampener

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -31,8 +31,9 @@ var
 	},
 
 	default_options = {
-		connect_timeout: 5000, // in ms
-		toobusy_lag:     150,  // in ms
+		connect_timeout:  5000, // in ms
+		toobusy_lag:      150,  // in ms
+		toobusy_dampener: 10,   // only works wih recent toobusy
 
 		health_check_delay: 45 // in s !!!
 	};
@@ -41,8 +42,15 @@ function Worker(options, band) {
 	events.EventEmitter.call(this);
 
 	this.options = util._extend(util._extend({}, default_options), options);
+
 	this.options.toobusy_lag = +this.options.toobusy_lag;
 	toobusy.maxLag(this.options.toobusy_lag);
+
+	this.options.toobusy_dampener = +this.options.toobusy_dampener;
+	if (toobusy.dampeningFactor) {
+		// old versions of toobusy do not expose dampeningFactor()
+		toobusy.dampeningFactor(this.options.toobusy_dampener);
+	}
 
 	this.band = band;
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -251,6 +251,7 @@ p.getInfo = function() {
 		pid:     process.pid,
 		mem:     process.memoryUsage(),
 		toobusy: toobusy(),
+		lag:     toobusy.lag(),
 		uptime:  process.uptime(),
 		portmap: this.options.portmap,
 		band:    this.band,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zopim",
   "name": "ipcluster",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "git@github.com:zopim/ipcluster.git"
@@ -14,7 +14,7 @@
     "commander": "~0.6.0",
     "q": "~0.9.7",
     "lodash": "~2.4.1",
-    "toobusy": "~0.2.4"
+    "toobusy": "git+ssh://git@github.com:zopim/node-toobusy.git"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
Using a fork of toobusy in our zopim account for now ([here](https://github.com/zopim/node-toobusy/), but trying to get the changes merged upstream so we don't need to maintain that fork at all (see this PR: https://github.com/lloyd/node-toobusy/pull/48 ).

@giantballofyarn @lennardseah @yangbin