### PR TITLE
Use toobusy-js as toobusy doesn't compile with node 0.12

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -264,6 +264,7 @@ p.getInfo = function() {
 	// this is to account for startup surge, and allow enough time for the garbage collector to reclaim some of the initialization memory
 	if (process.uptime() <= this.options.health_check_delay) {
 		info.toobusy = false;
+		info.lag     = 0;
 		for (var key in info.mem) info.mem[key] = 1;
 	}
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -249,6 +249,7 @@ p.getInfo = function() {
 		pid:     process.pid,
 		mem:     process.memoryUsage(),
 		toobusy: toobusy(),
+		lag:     toobusy.lag(),
 		uptime:  process.uptime(),
 		portmap: this.options.portmap,
 		band:    this.band,

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -16,7 +16,7 @@ var
 	net     = require('net'),
 	util    = require('util'),
 	events  = require('events'),
-	toobusy = require('toobusy'),
+	toobusy = require('toobusy-js'),
 
 	CommandProcessor = require('./CommandProcessor.js'),
 
@@ -31,18 +31,24 @@ var
 	},
 
 	default_options = {
-		connect_timeout: 5000, // in ms
-		toobusy_lag:     150,  // in ms
+		connect_timeout:    5000, // in ms
 
-		health_check_delay: 45 // in s !!!
+		toobusy_lag:        150,  // in ms
+		toobusy_smoothing:  0.1,  // only works wih recent toobusy-js
+
+		health_check_delay: 45    // in s !!!
 	};
 
 function Worker(options, band) {
 	events.EventEmitter.call(this);
 
 	this.options = util._extend(util._extend({}, default_options), options);
-	this.options.toobusy_lag = +this.options.toobusy_lag;
+
+	this.options.toobusy_lag       = +this.options.toobusy_lag;
+	this.options.toobusy_smoothing = +this.options.toobusy_smoothing;
+
 	toobusy.maxLag(this.options.toobusy_lag);
+	toobusy.smoothingFactor(this.options.toobusy_smoothing);
 
 	this.band = band;
 

--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
     "url": "git@github.com:zopim/ipcluster.git"
   },
   "engines": {
-    "node": "~0.8"
+    "node": ">=0.9.1"
   },
   "main": "lib/ipcluster.js",
   "dependencies": {
     "commander": "~0.6.0",
     "q": "~0.9.7",
     "lodash": "~2.4.1",
-    "toobusy": "~0.2.4"
+    "toobusy-js": "git+ssh://git@github.com:STRML/node-toobusy.git#3199f38dc3b"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
The old toobusy (c++) doesn't compile with node 0.12 and hasn't been maintained in 3 years. Recent development has moved to toobusy-js, a js-only implementation, which recently made the smoothing factor a tunable.

This PR upgrades from toobusy to toobusy-js, and sets a default smoothing factor of 0.1.

@giantballofyarn @lennardseah @yangbin @dineshsaravanan 