### PR TITLE
Renice failures should not cause exceptions

### DIFF
--- a/lib/clogger.js
+++ b/lib/clogger.js
@@ -2,13 +2,8 @@ module.exports = function(prefix) {
 	return function() {
 		var args = [].slice.call(arguments);
 
-		if (typeof args[0] === 'string') {
-			args[0] = prefix + ' ' + args[0];
-		}
-		else {
-			args.unshift(prefix);
-		}
+		args.unshift(prefix);
 
-		console.log.apply(this, args);
-	}
+		console.log.apply(console, args);
+	};
 };

--- a/lib/master.js
+++ b/lib/master.js
@@ -457,7 +457,10 @@ p.retire_worker = function(pid, reason_data) {
 
 	// finally, we instruct worker to go into retirement mode
 	worker.retire(reason);
-	putil.renice(pid, this.options.retire_renice).done();
+	putil
+		.renice(pid, this.options.retire_renice)
+		.fail(clog)
+		.done();
 
 	this.emit('retire', {
 		worker: worker,


### PR DESCRIPTION
Most of the time, renice fails because process has crashed and is already missing (making re-nicing it pointless anyway). So in the context of ipcluster, renice should just fail silently.

@giantballofyarn @dineshsaravanan @zz85 