### PR TITLE
Renice failures should not cause exceptions

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -457,7 +457,10 @@ p.retire_worker = function(pid, reason_data) {
 
 	// finally, we instruct worker to go into retirement mode
 	worker.retire(reason);
-	putil.renice(pid, this.options.retire_renice).done();
+	putil
+		.renice(pid, this.options.retire_renice)
+		.fail(noop) // we don't care about renice failures... typically process has already exited
+		.done();
 
 	this.emit('retire', {
 		worker: worker,


### PR DESCRIPTION
renice errors are currently causing uncaught exceptions. Typically, the renice fails if the process is already gone, and so from a renicing perspective, it's not important.

This PR catches and silences renice errors.

@lennardseah @giantballofyarn 