### PR TITLE
Implement soft kills (TERM-then-KILL) on high watermark

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -26,7 +26,7 @@ var default_options = {
 	monitor_interval:    1  * 1000, // 1s
 	totalmaxheap:        512 * 1024 * 1024, // 512 MB
 	spawn_delay:         2549, // large prime number to reduce overlapping cumulation delay
-	soft_kill_timeout:   5 * 1000, // 5s
+	soft_kill_timeout:   15 * 1000, // 15s
 	retire_rss:          448 * 1024 * 1024, // 448 MB
 	debug:               false,
 
@@ -615,7 +615,7 @@ p.make_worker = function(pid) {
 	});
 
 	worker.once('connect_timeout', destroyWorker.bind(this, pid, 'connect_timeout', 0));
-	worker.once('disconnected',    destroyWorker.bind(this, pid, 'disconnected',    0));
+	worker.once('disconnected',    destroyWorker.bind(this, pid, 'disconnected',    this.options.soft_kill_timeout));
 	worker.once('ping_timeout',    this.handleWorkerPingTimeout);
 	this.workers.set(pid, worker);
 
@@ -843,7 +843,7 @@ function handle_cluster_high_watermark(cluster_rss) {
 		var worker = old_workers_copy[idx];
 
 		worker_stats = worker.getStats();
-		destroyWorker.call(this, worker.pid, "high_watermark_panic", 0);
+		destroyWorker.call(this, worker.pid, "high_watermark_panic", this.options.soft_kill_timeout);
 		cluster_rss -= worker_stats.mem.rss;
 		breach_data.workers.push( worker_stats );
 		if (cluster_rss < this.options.cluster_heap_high_watermark) break;

--- a/lib/master.js
+++ b/lib/master.js
@@ -52,7 +52,7 @@ function Master(options) {
 	}
 
 	this.options.worker_retire_rss           = this.options.retire_rss;
-	this.options.cluster_heap_low_watermark  = this.options.totalmaxheap * 0.8;
+	this.options.cluster_heap_low_watermark  = this.options.totalmaxheap * 0.75;
 	this.options.cluster_heap_high_watermark = this.options.totalmaxheap * 0.95;
 
 	this.set_kill_strategy(Master.kill_strategies.conn_rss_time);

--- a/lib/process_util.js
+++ b/lib/process_util.js
@@ -115,7 +115,7 @@ function kill(pid, term_timeout) {
 			.spread( waitForProcessToDie )
 			.fail( ignore_missing_process_error )
 			.fail( hardkill )
-			.fail( ignore_missing_process_error )
+			.fail( ignore_missing_process_error );
 	}
 }
 
@@ -131,7 +131,7 @@ function waitForProcessToDie(pid, die_timeout) {
 
 	function cycle_check() {
 		processExists(pid)
-			.then(function(exists){
+			.then(function(exists) {
 				if (exists) {
 					if ((+new Date()) >= expire_at) {
 						deferred.reject( pid ); // process didn't die within allocated time
@@ -141,7 +141,7 @@ function waitForProcessToDie(pid, die_timeout) {
 					}
 				}
 				else {
-					deferred.resolve( pid )
+					deferred.resolve( pid );
 				}
 			})
 			.done();


### PR DESCRIPTION
Also lowers the low watermark threshold a bit, to allow more time for a given worker to process the die command, hopefully before high watermark is breached.

Note: Host app **must** implement a SIGTERM handler if it wants to do cleanup stuff.

@zz85 @giantballofyarn @dineshsaravanan 
