### PR TITLE
Introduce an API to handle termination (must be called by host app)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Features
 
 Dependencies
 ------------
-* npm modules - commander, q
+* npm modules - q, toobusy-js, lodash
 
 _IPCluster sticky sessions currently requires `iptables` for sticky sessions and so is Linux-only_
 

--- a/lib/master.js
+++ b/lib/master.js
@@ -26,7 +26,7 @@ var default_options = {
 	monitor_interval:    1  * 1000, // 1s
 	totalmaxheap:        512 * 1024 * 1024, // 512 MB
 	spawn_delay:         2549, // large prime number to reduce overlapping cumulation delay
-	soft_kill_timeout:   5 * 1000, // 5s
+	soft_kill_timeout:   15 * 1000, // 15s
 	retire_rss:          448 * 1024 * 1024, // 448 MB
 	debug:               false,
 
@@ -52,7 +52,7 @@ function Master(options) {
 	}
 
 	this.options.worker_retire_rss           = this.options.retire_rss;
-	this.options.cluster_heap_low_watermark  = this.options.totalmaxheap * 0.8;
+	this.options.cluster_heap_low_watermark  = this.options.totalmaxheap * 0.75;
 	this.options.cluster_heap_high_watermark = this.options.totalmaxheap * 0.95;
 
 	this.set_kill_strategy(Master.kill_strategies.conn_rss_time);
@@ -618,7 +618,7 @@ p.make_worker = function(pid) {
 	});
 
 	worker.once('connect_timeout', destroyWorker.bind(this, pid, 'connect_timeout', 0));
-	worker.once('disconnected',    destroyWorker.bind(this, pid, 'disconnected',    0));
+	worker.once('disconnected',    destroyWorker.bind(this, pid, 'disconnected',    this.options.soft_kill_timeout));
 	worker.once('ping_timeout',    this.handleWorkerPingTimeout);
 	this.workers.set(pid, worker);
 
@@ -846,7 +846,7 @@ function handle_cluster_high_watermark(cluster_rss) {
 		var worker = old_workers_copy[idx];
 
 		worker_stats = worker.getStats();
-		destroyWorker.call(this, worker.pid, "high_watermark_panic", 0);
+		destroyWorker.call(this, worker.pid, "high_watermark_panic", this.options.soft_kill_timeout);
 		cluster_rss -= worker_stats.mem.rss;
 		breach_data.workers.push( worker_stats );
 		if (cluster_rss < this.options.cluster_heap_high_watermark) break;

--- a/lib/process_util.js
+++ b/lib/process_util.js
@@ -115,7 +115,7 @@ function kill(pid, term_timeout) {
 			.spread( waitForProcessToDie )
 			.fail( ignore_missing_process_error )
 			.fail( hardkill )
-			.fail( ignore_missing_process_error )
+			.fail( ignore_missing_process_error );
 	}
 }
 
@@ -131,7 +131,7 @@ function waitForProcessToDie(pid, die_timeout) {
 
 	function cycle_check() {
 		processExists(pid)
-			.then(function(exists){
+			.then(function(exists) {
 				if (exists) {
 					if ((+new Date()) >= expire_at) {
 						deferred.reject( pid ); // process didn't die within allocated time
@@ -141,7 +141,7 @@ function waitForProcessToDie(pid, die_timeout) {
 					}
 				}
 				else {
-					deferred.resolve( pid )
+					deferred.resolve( pid );
 				}
 			})
 			.done();

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -24,10 +24,13 @@ var
 	PING_INTERVAL = 500, // 500ms
 
 	STATES = {
-		STARTING: 1,
-		RUNNING:  2,
-		SHUTDOWN: 3,
-		DEAD:     4
+		STARTING:     'STARTING',
+		CONNECTING:   'CONNECTING',
+		CONNECTED:    'CONNECTED',
+		DISCONNECTED: 'DISCONNECTED',
+		RUNNING:      'RUNNING',
+		RETIRED:      'RETIRED',
+		TERMINATED:   'TERMINATED'
 	},
 
 	default_options = {
@@ -61,7 +64,7 @@ function Worker(options, band) {
 	this.reconnect_TID = null;
 	this.ping_TID      = null;
 
-	this.state = 'STARTING';
+	this.state = STATES.STARTING;
 	this.ts_retirement = 0;
 
 	this.connection_attempts = 0;
@@ -99,7 +102,7 @@ p._connect_to_master = function() {
 	this.disconnected = false;
 
 	// if (this.connection_attempts++ % 50 === 0) clog('Attempt %d to connect to master', this.connection_attempts);
-	this.state = 'CONNECTING';
+	this.state = STATES.CONNECTING;
 	this.conn = net.connect( this.options.uds );
 
 	this.conn.once('error',   this._connection_error_handler);
@@ -115,7 +118,7 @@ p._schedule_reconnect_to_master = function() {
 
 p._connection_handler = function() {
 	clog('connected');
-	this.state = 'CONNECTED';
+	this.state = STATES.CONNECTED;
 
 	// connected successfully, remove listener for connection error
 	this.removeListener('error', this._connection_error_handler);
@@ -144,7 +147,7 @@ p._disconnect_handler = function() {
 	if (this.disconnected) return;
 	this.disconnected = true;
 
-	this.state = 'DISCONNECTED';
+	this.state = STATES.DISCONNECTED;
 
 	if (this.ping_TID) {
 		this.ping_TID = clearInterval(this.ping_TID);
@@ -162,7 +165,7 @@ p._disconnect_handler = function() {
 	this.connection_attempts = 0;
 
 	// TODO fix the condition to prevent invalid reconnections
-	if (this.state != STATES.SHUTDOWN && this.state != STATES.DEAD) {
+	if (this.state != STATES.TERMINATED) {
 		this._schedule_reconnect_to_master();
 	}
 };
@@ -203,7 +206,7 @@ p._retire_handler = function(msg) {
 	this.iface.reply({}, msg); // ok ack reply
 
 	this.ts_retirement = +new Date();
-	this.state = 'RETIRED';
+	this.state = STATES.RETIRED;
 
 	this.emit('command_retire', msg);  // inform host app
 };
@@ -282,6 +285,11 @@ p.getInfo = function() {
 	}
 
 	return info;
+};
+
+p.terminate = function() {
+	this.state = STATES.TERMINATED;
+	this._disconnect_handler();
 };
 
 // needs to be called by host app prior to exiting

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zopim",
   "name": "ipcluster",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "repository": {
     "type": "git",
     "url": "git@github.com:zopim/ipcluster.git"
@@ -11,7 +11,6 @@
   },
   "main": "lib/ipcluster.js",
   "dependencies": {
-    "commander": "~2.8.1",
     "q": "~1.4.1",
     "lodash": "~3.10.1",
     "toobusy-js": "git+ssh://git@github.com:STRML/node-toobusy.git#3199f38dc3b"


### PR DESCRIPTION
When we introduced a soft kill in the previous PR allows worker to attempt to reconnect to the master. 

Ideally, I'd want the worker to capture the TERM signal and terminate itself from an ipcluster perspective. I don't want to do that however, because when a library like ipcluster captures the TERM signal, it takes away the responsibility of the host app, which might want to just die on TERM.

So Instead, this PR introduces a `terminate()` API call onthe worker that thehost ap is supposed to call.

@zz85 @giantballofyarn @dineshsaravanan 
