### PR TITLE
use GitHub URL for node-toobusy to avoid npm install git failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "commander": "~2.8.1",
     "q": "~1.4.1",
     "lodash": "~3.10.1",
-    "toobusy-js": "git+ssh://git@github.com:STRML/node-toobusy.git#3199f38dc3b"
+    "toobusy-js": "STRML/node-toobusy#v0.4.3"
   },
   "devDependencies": {
     "grunt": "0.4.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "commander": "~2.8.1",
     "q": "~1.4.1",
     "lodash": "~3.10.1",
-    "toobusy-js": "STRML/node-toobusy#v0.4.3"
+    "toobusy-js": "0.4.3"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
@timotheeg @dineshsaravanan 

Tested locally, build works with node 4.x