### PR TITLE
Iptables: Don't retry or throw when deleting non-existent rules

### DIFF
--- a/lib/iptables.js
+++ b/lib/iptables.js
@@ -280,11 +280,22 @@ function exec_next() {
 
 	exec(cmd, { timeout: CMD_TIMEOUT }, function(error, stdout /*, stderr */) {
 		if (error) {
-			if (--tries_left <= 0) throw error + ' / Cannot run ' + cmd;
-			log('Warning: cannot run command: ' + cmd);
-			exec_queue.unshift([cmd, cb, tries_left]);
-			setTimeout(exec_next, CMD_RETRY_DELAY * (CMD_MAX_TRIES - tries_left));
-			return;
+			// Warning: iptables doesn't have exhaustive return codes
+			// Failure reason is in the stderr message instead, and so we must do a string comparison
+			if (/ -D PREROUTING .+ No chain.target.match by that name/i.test(error + '')) {
+				// Trying to delete a rule that's not there
+				// Something is "weird", but it should not be a blocking error
+				// TODO: investigate how/why this might happen
+				log('Warning: Attempting to delete a rule that\'s not present');
+			}
+			else {
+				// Real error that's worth retrying or reporting
+				if (--tries_left <= 0) throw error + ' / Cannot run ' + cmd;
+				log('Warning: cannot run command: ' + cmd);
+				exec_queue.unshift([cmd, cb, tries_left]);
+				setTimeout(exec_next, CMD_RETRY_DELAY * (CMD_MAX_TRIES - tries_left));
+				return;
+			}
 		}
 
 		cb && cb(stdout);


### PR DESCRIPTION
### Context
We use a queue system to run the commands that remove and insert iptables rules. failures in those commands are handled via a retry system (5 times). In case of 5 consecutive failures, we throw so the error can be reported to sentry (see example here https://sentry.zopim.com/zopim/dashboard-mediator/issues/222510/)

For some reason, the code sometimes attempts to remove a rule that's not present. The net effect is good (we want it gone, it's gone), but iptables still reports this as an error, which is basically not recoverable, no matter how many times we try.

However, when we throw, the queue execution lock is not cleared, and so the master will then be stuck "forever" with no new worker ever being able to get its port map honoured.


### Approach
The PR detects the case of "removal of non-existent rule" and treats it as a success. Because iptables doesn't have detailed error code, we are forced to do a string comparison on the error message itself.

More investigations are needed to check why the "bad removals" occurs, but the PR should get the offending cases away first.

One possible improvements could also to clear the queue lock before throwing, but I'm not doing that now as the iptables rules would overall be in a undetermined state anyway.

@zopim/catalyst @hvgirish @dineshsaravanan

### Risks
Could break the command queue system used in ipcluster


