### PR TITLE
Iptables: match newline characters too when doing safe rule removal

### DIFF
--- a/lib/iptables.js
+++ b/lib/iptables.js
@@ -282,7 +282,8 @@ function exec_next() {
 		if (error) {
 			// Warning: iptables doesn't have exhaustive return codes
 			// Failure reason is in the stderr message instead, and so we must do a string comparison
-			if (/ -D PREROUTING .+ No chain.target.match by that name/i.test(error + '')) {
+			// Note: [^]+ matches any character including newline
+			if (/ -D PREROUTING [^]+ No chain.target.match by that name/i.test(error + '')) {
 				// Trying to delete a rule that's not there
 				// Something is "weird", but it should not be a blocking error
 				// TODO: investigate how/why this might happen

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zopim",
   "name": "ipcluster",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "git@github.com:zopim/ipcluster.git"


### PR DESCRIPTION
### Context
The [previous PR](https://github.com/zopim/ipcluster/pull/20) was tested against a error string that did not contains a newline character and passed the regexp matchg. Turns out, the error message **does** contain a newline character, causing the code to not catch the invalid error.

### Approach
Match newline character as well through the very fancy `[^]+` (don't match nothing... which matches everything. Yay!)

@zopim/catalyst @hvgirish 

### Risks
None