### PR TITLE
Prevent exec_queue lock on consecutive iptables error

### DIFF
--- a/lib/iptables.js
+++ b/lib/iptables.js
@@ -39,7 +39,7 @@ var
 	},
 	CMD_TIMEOUT     = 1000,
 	CMD_MAX_TRIES   = 5,
-	CMD_RETRY_DELAY = 25
+	CMD_RETRY_DELAY = 40
 ;
 
 module.exports = IPTSet;
@@ -291,15 +291,26 @@ function exec_next() {
 			}
 			else {
 				// Real error that's worth retrying or reporting
-				if (--tries_left <= 0) throw error + ' / Cannot run ' + cmd;
-				log('Warning: cannot run command: ' + cmd);
-				exec_queue.unshift([cmd, cb, tries_left]);
-				setTimeout(exec_next, CMD_RETRY_DELAY * (CMD_MAX_TRIES - tries_left));
-				return;
+				log('Warning: cannot run command: ' + cmd + '; ' + error);
+
+				if (--tries_left > 0) {
+					exec_queue.unshift([cmd, cb, tries_left]);
+					setTimeout(exec_next, CMD_RETRY_DELAY * (CMD_MAX_TRIES - tries_left));
+					return;
+				}
+				/*
+				else {
+					// There's no tries left but the command still cannot execute (for some reason?)
+					// We used to throw here, but that would cause exec_lock to never be reset and lock the master up entirely.
+					// We now do nothing ON PURPOSE. The current failed command might prevent one worker to work correctly,
+					// but the master overall will carry on.
+					// TODO: find out why/when/how can iptables commands fail
+				}
+				/**/
 			}
 		}
 
-		cb && cb(stdout);
+		cb && cb(stdout || '');
 		setTimeout(exec_next, CMD_RETRY_DELAY);
 	});
 }


### PR DESCRIPTION
When the iptables command fail past the max retries, throwing effectively locks the execution queue and locks the master up completely.

This PR:
* Stops throwing; after the last error, we'll call the callback and carry on with the next iptables command
* Increases the retry delay from 25ms to 40ms, to hopefully provide more chances of a failure converting into a success 

Note:
This is not ideal. The callback is now being called without guarantee of success, some workers might not be operable, but at least the master overall is not completely locked up.

@trungnn @hvgirish @appsan @giantballofyarn 

