### PR TITLE
Version bump to v0.0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "Zopim",
   "name": "ipcluster",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "repository": {
     "type": "git",
     "url": "git@github.com:zopim/ipcluster.git"


### PR DESCRIPTION
Version bump includes:
* prevents master lock up on consecutive iptables command errors #23 

@zopim/catalyst @giantballofyarn 